### PR TITLE
Сохранить поведение regex паттернов после обновления на java 19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.26</lombok.version>
         <checkerframework.version>3.26.0</checkerframework.version>
     </properties>
 

--- a/src/main/java/org/spacious_team/table_wrapper/api/PatternTableColumn.java
+++ b/src/main/java/org/spacious_team/table_wrapper/api/PatternTableColumn.java
@@ -29,8 +29,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static java.util.regex.Pattern.UNICODE_CASE;
+import static java.util.regex.Pattern.*;
 import static lombok.AccessLevel.PRIVATE;
 
 /**
@@ -92,6 +91,6 @@ public class PatternTableColumn implements TableColumn {
 
 
     private static Pattern toPattern(String pattern) {
-        return Pattern.compile(pattern, CASE_INSENSITIVE | UNICODE_CASE);
+        return Pattern.compile(pattern, CASE_INSENSITIVE | UNICODE_CASE | UNICODE_CHARACTER_CLASS);
     }
 }

--- a/src/test/java/org/spacious_team/table_wrapper/api/PatternTableColumnTest.java
+++ b/src/test/java/org/spacious_team/table_wrapper/api/PatternTableColumnTest.java
@@ -56,6 +56,8 @@ class PatternTableColumnTest {
         assertEquals(21, PatternTableColumn.of("mac").getColumnIndex(row));
         assertEquals(22, PatternTableColumn.of("windows").getColumnIndex(row));
         assertEquals(22, PatternTableColumn.of("windows").getColumnIndex(21, row));
+        assertEquals(23, PatternTableColumn.of("\\bмягких\\b").getColumnIndex(row));
+        assertEquals(23, PatternTableColumn.of("\\bбулочек\\b").getColumnIndex(row));
 
         TableColumn column1 = PatternTableColumn.of("windows");
         assertThrows(TableColumnNotFound.class, () -> column1.getColumnIndex(23, row));

--- a/src/test/java/org/spacious_team/table_wrapper/api/ReportPageRowHelper.java
+++ b/src/test/java/org/spacious_team/table_wrapper/api/ReportPageRowHelper.java
@@ -45,7 +45,8 @@ final class ReportPageRowHelper {
                 cell("This Is Sparta", 10),
                 cell("London\nis the\ncapital\nof Great Britain", 20),
                 cell("The Mac\rnew line", 21),
-                cell("The Windows\r\nnew line", 22));
+                cell("The Windows\r\nnew line", 22),
+                cell("Съешь еще этих\nмягких французских булочек.", 23));
     }
 
     /**


### PR DESCRIPTION
В java 19 есть несовместимые изменения

> Regex \b Character Class Now Matches ASCII Characters only by Default ([JDK-8264160](https://bugs.openjdk.org/browse/JDK-8264160))
>
> The \b metacharacter now matches ASCII word characters by default in the same way that the \w metacharacter does. For \b to match Unicode characters, the UNICODE_CHARACTER_CLASS must be set in the same way that it would need to be set for \w to match Unicode characters.

Источник: https://www.oracle.com/java/technologies/javase/19-relnote-issues.html

Relates spacious-team/investbook#524